### PR TITLE
Use an executable `dogma` instead of `mix`

### DIFF
--- a/flycheck-elixir-dogma.el
+++ b/flycheck-elixir-dogma.el
@@ -42,7 +42,7 @@
 
 (flycheck-define-checker elixir-dogma
   "Defines a checker for elixir with dogma"
-  :command ("mix" "dogma" "--format=flycheck" source-inplace)
+  :command ("dogma" "--format=flycheck" source-inplace)
   :error-patterns
   ((info line-start (file-name) ":" line ":" column ": C: "
          (optional (id (one-or-more (not (any ":")))) ": ") (message) line-end)


### PR DESCRIPTION
In the docs you're instructing to install dogma locally but the checker is using `mix` instead. When using mix and checking file that is not under root I get error "Suspicious state from syntax checker elixir-dogma: Checker elixir-dogma returned non-zero exit code 1, but no errors from output: *\* (Mix) The task "dogma" could not be found"
